### PR TITLE
Add basic functionality

### DIFF
--- a/apps/ogclockremake/manifest.yaml
+++ b/apps/ogclockremake/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: og-clock-remake
+name: OG Clock Remake
+summary: OG Clock Remake
+desc: A remake of the original Tidbyt Clock App (Reddit initiative).
+author: bendiep
+fileName: og_clock_remake.star
+packageName: ogclockremake

--- a/apps/ogclockremake/og_clock_remake.star
+++ b/apps/ogclockremake/og_clock_remake.star
@@ -2,82 +2,243 @@
 Applet: OG Clock Remake
 Summary: OG Clock Remake
 Description: A remake of the original Tidbyt Clock App (Reddit initiative).
-Author: bendiep
+Author: bendiep + Josiah Winslow
 
 TODO:
-- Get real weather data from API
 - Get more weather icons
-- Get timezone from location
-- Add display location toggle option
-- Add 24-hour clock toggle option
-- Add display weather toggle option
-- Add blinking separator toggle option
-- Add temperature units option (Celsius/Fahrenheit)
-- Add time color option
+
+NOTE:
+- "weatherCode" corresponds to codes from this API: https://www.worldweatheronline.com/weather-api/api/docs/weather-icons.aspx
 """
 
 load("encoding/base64.star", "base64")
+load("encoding/json.star", "json")
+load("http.star", "http")
 load("render.star", "render")
+load("schema.star", "schema")
 load("time.star", "time")
 
+DEFAULT_LOCATION = """
+{
+    "lat": "40.6781784",
+    "lng": "-73.9441579",
+    "description": "Brooklyn, NY, USA",
+    "locality": "Brooklyn",
+    "place_id": "ChIJCSF8lBZEwokRhngABHRcdoI",
+    "timezone": "America/New_York"
+}
+"""
+DEFAULT_TIMEZONE = "America/New_York"
+DEFAULT_TIME_COLOR = "#FFF"
+UNIT_NAMES = {
+    "f": "temp_F",
+    "c": "temp_C",
+}
+
+TTL_SECONDS = 60  # 1 minute
+
+INFO_COLOR = "#FFF"
+HUMIDITY_COLOR = "#66F"
+
+PLACEHOLDER_WEATHER_DATA = {
+    "current_condition": {
+        "humidity": "97",
+        "temp_C": "12",
+        "temp_F": "54",
+        "weatherCode": "296",
+    },
+}
+
 PLACEHOLDER_WEATHER_ICON = base64.decode("""
-iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAVFBMVEVHcEwOCgAAAAAAAACFciD/5UgAAAD/4kcAAAAAAAAfGQQAAAAAAAAyKQYJBwEAAAATDwIJBgA8Mwr/40f/2kT92EPmxDzLrTTDpjFvXhf710P71kNJ8ar5AAAAFHRSTlMASkp6uvwJ+2/ohIGGqLECe6uc+nKi/4AAAACcZVhJZk1NACoAAAAIAAYBEgADAAAAAQABAAABGgAFAAAAAQAAAFYBGwAFAAAAAQAAAF4BKAADAAAAAQACAAACEwADAAAAAQABAACHaQAEAAAAAQAAAGYAAAAAAAAAWgAAAAEAAABaAAAAAQAEkAAABwAAAAQwMjMykQEABwAAAAQBAgMAoAAABwAAAAQwMTAwoAEAAwAAAAEAAQAAAAAAABbGwGQAAAB5SURBVBjTZU9HEsQwCJNb3L0p65Lk//8MXG0ODNIgkPADNsQClEgDCO4CCBnIARA7qB0SzqfkHeQheF+eSvcxulanZBWg7masNe1WjGJwul1Prc/VtAsRJftu3j/Va7rP9A5p2MpEtSOxZiYWyXJ0ebsam60v4eb4H0J7CeWxaizWAAAAAElFTkSuQmCC
+UklGRvQCAABXRUJQVlA4WAoAAAAwAAAADAAADAAASUNDUKACAAAAAAKgbGNtcwRAAABtbnRyUkdCIFh
+ZWiAH6QAFAB0ACgATAANhY3NwTVNGVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9tYAAQAAAADTLW
+xjbXMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1kZXNjAAABI
+AAAAEBjcHJ0AAABYAAAADZ3dHB0AAABmAAAABRjaGFkAAABrAAAACxyWFlaAAAB2AAAABRiWFlaAAAB
+7AAAABRnWFlaAAACAAAAABRyVFJDAAACFAAAACBnVFJDAAACFAAAACBiVFJDAAACFAAAACBjaHJtAAA
+CNAAAACRkbW5kAAACWAAAACRkbWRkAAACfAAAACRtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACQAAAAcAE
+cASQBNAFAAIABiAHUAaQBsAHQALQBpAG4AIABzAFIARwBCbWx1YwAAAAAAAAABAAAADGVuVVMAAAAaA
+AAAHABQAHUAYgBsAGkAYwAgAEQAbwBtAGEAaQBuAABYWVogAAAAAAAA9tYAAQAAAADTLXNmMzIAAAAA
+AAEMQgAABd7///MlAAAHkwAA/ZD///uh///9ogAAA9wAAMBuWFlaIAAAAAAAAG+gAAA49QAAA5BYWVo
+gAAAAAAAAJJ8AAA+EAAC2xFhZWiAAAAAAAABilwAAt4cAABjZcGFyYQAAAAAAAwAAAAJmZgAA8qcAAA
+1ZAAAT0AAACltjaHJtAAAAAAADAAAAAKPXAABUfAAATM0AAJmaAAAmZwAAD1xtbHVjAAAAAAAAAAEAA
+AAMZW5VUwAAAAgAAAAcAEcASQBNAFBtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJW
+UDhMLgAAAC8MAAMQDzD/8z//8x/wUNRIktK7x3/UczllpxRFRfQ/YNPNt9lpWnFEa6ftZgM=
 """)
 
-def main():
-    # Time
-    timezone = "Australia/Melbourne"  # Placeholder timezone
+def get_weather(location):
+    weather = PLACEHOLDER_WEATHER_DATA
+
+    # Source of weather information is wttr.in
+    url = "http://wttr.in/%s,%s?format=j1" % (location["lat"], location["lng"])
+    rep = http.get(url, ttl_seconds = TTL_SECONDS)
+    if rep.status_code == 200:
+        weather = rep.json()
+
+    return weather["current_condition"][0]
+
+def main(config):
+    # Get location and timezone
+    location = json.decode(config.get("location", DEFAULT_LOCATION))
+    timezone = location.get("timezone", config.get("$tz", DEFAULT_TIMEZONE))
+
+    # Get more config options
+    time_color = config.get("time_color", DEFAULT_TIME_COLOR)
+    use_24hclock = config.bool("24hclock", False)
+    blink = config.bool("blink", True)
+    unit = config.str("unit", "f")
+    display_location = config.bool("display_location", False)
+    display_weather = config.bool("display_weather", True)
+
+    # Get current time
     now = time.now().in_location(timezone)
 
-    # Weather
-    temperature = "69"  # Placeholder temperature
-    precipitation = "48%"  # Placeholder precipitation
+    # Render time
+    time_format = "03:04" if use_24hclock else "3:04 PM"
+    time_format_blink = time_format
+    if blink:
+        time_format_blink = time_format_blink.replace(":", " ")
+    text_time = render.Text(
+        content = now.format(time_format),
+        font = "6x13",
+        color = time_color,
+        height = 11,
+        offset = -1,
+    )
+    text_time_blink = render.Text(
+        content = now.format(time_format_blink),
+        font = "6x13",
+        color = time_color,
+        height = 11,
+        offset = -1,
+    )
+    component_time = render.Animation(
+        children = [text_time] * 4 + [text_time_blink] * 4,
+    )
 
-    # Layout
+    # Render location
+    component_location = None
+    if display_location:
+        component_location = render.Marquee(
+            width = 64,
+            align = "center",
+            child = render.Text(
+                content = location["locality"],
+                font = "5x8",
+                color = INFO_COLOR,
+                height = 7,
+            ),
+        )
+
+    # Render weather
+    unit_name = UNIT_NAMES[unit]
+    component_weather = None
+    if display_weather:
+        weather = get_weather(location)
+        component_weather = render.Row(
+            cross_align = "center",
+            children = [
+                render.Padding(
+                    pad = (0, 0, 1, 0),
+                    child = render.Image(src = PLACEHOLDER_WEATHER_ICON),
+                ),
+                render.Column(
+                    children = [
+                        render.Text(
+                            content = weather[unit_name],
+                            font = "5x8",
+                            color = INFO_COLOR,
+                            height = 7,
+                        ),
+                        render.Text(
+                            content = "%s%%" % weather["humidity"],
+                            font = "5x8",
+                            color = HUMIDITY_COLOR,
+                            height = 7,
+                        ),
+                    ],
+                ),
+            ],
+        )
+
     return render.Root(
-        delay = 500,
+        delay = 125,
         child = render.Box(
-            render.Column(
+            child = render.Column(
                 expanded = True,
-                main_align = "space_evenly",
+                main_align = "space_around",
                 cross_align = "center",
                 children = [
-                    # Render Time
-                    render.Animation(
-                        children = [
-                            render.Text(
-                                content = now.format("3:04 PM"),
-                                font = "6x13",
-                            ),
-                            render.Text(
-                                content = now.format("3 04 PM"),
-                                font = "6x13",
-                            ),
-                        ],
-                    ),
-                    render.Row(
-                        cross_align = "center",
-                        children = [
-                            # Render Weather Icon
-                            render.Image(src = PLACEHOLDER_WEATHER_ICON),
-                            render.Column(
-                                children = [
-                                    # Render Temperature
-                                    render.Text(
-                                        content = temperature,
-                                        font = "5x8",
-                                    ),
-                                    # Render Precipitation
-                                    render.Text(
-                                        content = precipitation,
-                                        font = "5x8",
-                                        color = "#848fEE",
-                                    ),
-                                ],
-                            ),
-                        ],
-                    ),
+                    component_time,
+                    component_weather,
+                    component_location,
                 ],
             ),
         ),
+    )
+
+def get_schema():
+    options_unit = [
+        schema.Option(
+            display = "Fahrenheit",
+            value = "f",
+        ),
+        schema.Option(
+            display = "Celsius",
+            value = "c",
+        ),
+    ]
+
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Location(
+                id = "location",
+                name = "Location",
+                desc = "Location for which to display time.",
+                icon = "locationArrow",
+            ),
+            schema.Toggle(
+                id = "display_location",
+                name = "Display location",
+                desc = "Show location in addition to time.",
+                icon = "locationDot",
+                default = False,
+            ),
+            schema.Toggle(
+                id = "24hclock",
+                name = "24 hour clock",
+                desc = "Use 24 hour time format.",
+                icon = "clock",
+                default = False,
+            ),
+            schema.Toggle(
+                id = "display_weather",
+                name = "Display weather",
+                desc = "Show weather information in addition to time.",
+                icon = "cloud",
+                default = True,
+            ),
+            schema.Dropdown(
+                id = "unit",
+                name = "Temperature units",
+                desc = "Preferred units for temperature information.",
+                icon = "temperatureHalf",
+                default = options_unit[0].value,
+                options = options_unit,
+            ),
+            schema.Color(
+                id = "time_color",
+                name = "Time color",
+                desc = "Color of the time component.",
+                icon = "brush",
+                default = DEFAULT_TIME_COLOR,
+            ),
+            schema.Toggle(
+                id = "blink",
+                name = "Blinking separator",
+                desc = "Make the hour-minute separator blink.",
+                icon = "gear",
+                default = True,
+            ),
+        ],
     )

--- a/apps/ogclockremake/og_clock_remake.star
+++ b/apps/ogclockremake/og_clock_remake.star
@@ -29,14 +29,14 @@ def main():
     timezone = "Australia/Melbourne"
     now = time.now().in_location(timezone)
 
-    # Layout 
+    # Layout
     return render.Root(
         delay = 500,
         child = render.Box(
             render.Column(
-                expanded=True,
-                main_align="space_evenly",
-                cross_align="center",
+                expanded = True,
+                main_align = "space_evenly",
+                cross_align = "center",
                 children = [
                     # Render Time
                     render.Animation(
@@ -49,10 +49,10 @@ def main():
                                 content = now.format("3 04 PM"),
                                 font = "6x13",
                             ),
-                        ]
+                        ],
                     ),
                     # Render Weather Placeholder
-                    render.Image(src=PLACEHOLDER_WEATHER_ICON),
+                    render.Image(src = PLACEHOLDER_WEATHER_ICON),
                 ],
             ),
         ),

--- a/apps/ogclockremake/og_clock_remake.star
+++ b/apps/ogclockremake/og_clock_remake.star
@@ -13,15 +13,16 @@ iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAVFBMVEVHcEwOCgAAAAAAAACFciD/5UgA
 """)
 
 def main():
-    # return render.Root(
-    #     child = render.Text("Hello, World!")
-    # )
-
     return render.Root(
-        child = render.Row( # Row lays out its children horizontally
+        child = render.Box(
+            render.Column(
+                expanded=True,
+                main_align="space_evenly",
+                cross_align="center",
                 children = [
+                    render.Text("Time"),
                     render.Image(src=PLACEHOLDER_WEATHER_ICON),
-                    render.Text("Hello, World!")
                 ],
-        )
+            ),
+        ),
     )

--- a/apps/ogclockremake/og_clock_remake.star
+++ b/apps/ogclockremake/og_clock_remake.star
@@ -5,9 +5,23 @@ Description: A remake of the original Tidbyt Clock App (Reddit initiative).
 Author: bendiep
 """
 
+load("encoding/base64.star", "base64")
 load("render.star", "render")
 
+PLACEHOLDER_WEATHER_ICON = base64.decode("""
+iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAVFBMVEVHcEwOCgAAAAAAAACFciD/5UgAAAD/4kcAAAAAAAAfGQQAAAAAAAAyKQYJBwEAAAATDwIJBgA8Mwr/40f/2kT92EPmxDzLrTTDpjFvXhf710P71kNJ8ar5AAAAFHRSTlMASkp6uvwJ+2/ohIGGqLECe6uc+nKi/4AAAACcZVhJZk1NACoAAAAIAAYBEgADAAAAAQABAAABGgAFAAAAAQAAAFYBGwAFAAAAAQAAAF4BKAADAAAAAQACAAACEwADAAAAAQABAACHaQAEAAAAAQAAAGYAAAAAAAAAWgAAAAEAAABaAAAAAQAEkAAABwAAAAQwMjMykQEABwAAAAQBAgMAoAAABwAAAAQwMTAwoAEAAwAAAAEAAQAAAAAAABbGwGQAAAB5SURBVBjTZU9HEsQwCJNb3L0p65Lk//8MXG0ODNIgkPADNsQClEgDCO4CCBnIARA7qB0SzqfkHeQheF+eSvcxulanZBWg7masNe1WjGJwul1Prc/VtAsRJftu3j/Va7rP9A5p2MpEtSOxZiYWyXJ0ebsam60v4eb4H0J7CeWxaizWAAAAAElFTkSuQmCC
+""")
+
 def main():
+    # return render.Root(
+    #     child = render.Text("Hello, World!")
+    # )
+
     return render.Root(
-        child = render.Text("Hello, World!")
+        child = render.Row( # Row lays out its children horizontally
+                children = [
+                    render.Image(src=PLACEHOLDER_WEATHER_ICON),
+                    render.Text("Hello, World!")
+                ],
+        )
     )

--- a/apps/ogclockremake/og_clock_remake.star
+++ b/apps/ogclockremake/og_clock_remake.star
@@ -1,0 +1,13 @@
+"""
+Applet: OG Clock Remake
+Summary: OG Clock Remake
+Description: A remake of the original Tidbyt Clock App (Reddit initiative).
+Author: bendiep
+"""
+
+load("render.star", "render")
+
+def main():
+    return render.Root(
+        child = render.Text("Hello, World!")
+    )

--- a/apps/ogclockremake/og_clock_remake.star
+++ b/apps/ogclockremake/og_clock_remake.star
@@ -3,6 +3,17 @@ Applet: OG Clock Remake
 Summary: OG Clock Remake
 Description: A remake of the original Tidbyt Clock App (Reddit initiative).
 Author: bendiep
+
+TODO:
+- Get real weather data from API
+- Get more weather icons
+- Get timezone from location
+- Add display location toggle option
+- Add 24-hour clock toggle option
+- Add display weather toggle option
+- Add blinking separator toggle option
+- Add temperature units option (Celsius/Fahrenheit)
+- Add time color option
 """
 
 load("encoding/base64.star", "base64")

--- a/apps/ogclockremake/og_clock_remake.star
+++ b/apps/ogclockremake/og_clock_remake.star
@@ -7,20 +7,40 @@ Author: bendiep
 
 load("encoding/base64.star", "base64")
 load("render.star", "render")
+load("time.star", "time")
 
 PLACEHOLDER_WEATHER_ICON = base64.decode("""
 iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAVFBMVEVHcEwOCgAAAAAAAACFciD/5UgAAAD/4kcAAAAAAAAfGQQAAAAAAAAyKQYJBwEAAAATDwIJBgA8Mwr/40f/2kT92EPmxDzLrTTDpjFvXhf710P71kNJ8ar5AAAAFHRSTlMASkp6uvwJ+2/ohIGGqLECe6uc+nKi/4AAAACcZVhJZk1NACoAAAAIAAYBEgADAAAAAQABAAABGgAFAAAAAQAAAFYBGwAFAAAAAQAAAF4BKAADAAAAAQACAAACEwADAAAAAQABAACHaQAEAAAAAQAAAGYAAAAAAAAAWgAAAAEAAABaAAAAAQAEkAAABwAAAAQwMjMykQEABwAAAAQBAgMAoAAABwAAAAQwMTAwoAEAAwAAAAEAAQAAAAAAABbGwGQAAAB5SURBVBjTZU9HEsQwCJNb3L0p65Lk//8MXG0ODNIgkPADNsQClEgDCO4CCBnIARA7qB0SzqfkHeQheF+eSvcxulanZBWg7masNe1WjGJwul1Prc/VtAsRJftu3j/Va7rP9A5p2MpEtSOxZiYWyXJ0ebsam60v4eb4H0J7CeWxaizWAAAAAElFTkSuQmCC
 """)
 
 def main():
+    # Time
+    timezone = "Australia/Melbourne"
+    now = time.now().in_location(timezone)
+
+    # Layout 
     return render.Root(
+        delay = 500,
         child = render.Box(
             render.Column(
                 expanded=True,
                 main_align="space_evenly",
                 cross_align="center",
                 children = [
-                    render.Text("Time"),
+                    # Render Time
+                    render.Animation(
+                        children = [
+                            render.Text(
+                                content = now.format("3:04 PM"),
+                                font = "6x13",
+                            ),
+                            render.Text(
+                                content = now.format("3 04 PM"),
+                                font = "6x13",
+                            ),
+                        ]
+                    ),
+                    # Render Weather Placeholder
                     render.Image(src=PLACEHOLDER_WEATHER_ICON),
                 ],
             ),

--- a/apps/ogclockremake/og_clock_remake.star
+++ b/apps/ogclockremake/og_clock_remake.star
@@ -26,8 +26,12 @@ iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAVFBMVEVHcEwOCgAAAAAAAACFciD/5UgA
 
 def main():
     # Time
-    timezone = "Australia/Melbourne"
+    timezone = "Australia/Melbourne"  # Placeholder timezone
     now = time.now().in_location(timezone)
+
+    # Weather
+    temperature = "69"  # Placeholder temperature
+    precipitation = "48%"  # Placeholder precipitation
 
     # Layout
     return render.Root(
@@ -51,8 +55,28 @@ def main():
                             ),
                         ],
                     ),
-                    # Render Weather Placeholder
-                    render.Image(src = PLACEHOLDER_WEATHER_ICON),
+                    render.Row(
+                        cross_align = "center",
+                        children = [
+                            # Render Weather Icon
+                            render.Image(src = PLACEHOLDER_WEATHER_ICON),
+                            render.Column(
+                                children = [
+                                    # Render Temperature
+                                    render.Text(
+                                        content = temperature,
+                                        font = "5x8",
+                                    ),
+                                    # Render Precipitation
+                                    render.Text(
+                                        content = precipitation,
+                                        font = "5x8",
+                                        color = "#848fEE",
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
                 ],
             ),
         ),


### PR DESCRIPTION
I took the liberty of analyzing how the stock Tidbyt Clock app works, and I think I have a version here that replicates its functionality as well as possible with what I have access to. Here are the features I've replicated thus far:

- The user's location is accessed via a schema item, falling back to a default location of Brooklyn, New York if that fails. This is also how the timezone is accessed (though it falls back to `$tz` before using Brooklyn time).
- - I don't actually know what happens if the location isn't specified - perhaps it uses CEST, like in the preview on its website - but Tidbyt has used Brooklyn as a default location in some of its public example code.
- The heights and offsets of each component - time, weather, and location - are tuned to match the layout of Tidbyt's Clock, which I've tested against all four possible formats.
- The two numbers shown in the weather component are temperature and _humidity_, not temperature and precipitation.
- By specifying a location with a long name, I discovered that Tidbyt's Clock is rendered with a delay of 125ms; this is the delay used here. (This also means that the blinking animation takes 8 frames in total - 4 on, and 4 off.)
- By using Chrome DevTools on tidbyt.app, I was able to access the exact IDs of each schema item. The schema items are given these IDs.

There are only two things I don't know about Tidbyt's Clock at the moment:

- I do not know exactly which icons are used and when. I'm guessing the icons are 13x13, and I've accounted for this in the design. More analysis will be needed to compile all the icons used.
- I do not know the source of the weather data. I'm guessing it's the enterprise tier of some paid API, but I have no way of knowing which one. The source of weather data in my remake is [wttr.in](https://github.com/chubin/wttr.in), which I used because it's free and it doesn't require an API key; this could be swapped out for a different source if needed.